### PR TITLE
refactor: update deprecated task identifiers in examples

### DIFF
--- a/src/test/resources/flows/comment-jira.yaml
+++ b/src/test/resources/flows/comment-jira.yaml
@@ -14,7 +14,7 @@ listeners:
 
 tasks:
   - id: seq
-    type: io.kestra.core.tasks.flows.Sequential
+    type: io.kestra.plugin.core.flow.Sequential
     tasks:
       - id: failed
-        type: io.kestra.core.tasks.executions.Fail
+        type: io.kestra.plugin.core.execution.Fail

--- a/src/test/resources/flows/jira.yaml
+++ b/src/test/resources/flows/jira.yaml
@@ -18,7 +18,7 @@ listeners:
 
 tasks:
   - id: seq
-    type: io.kestra.core.tasks.flows.Sequential
+    type: io.kestra.plugin.core.flow.Sequential
     tasks:
       - id: failed
-        type: io.kestra.core.tasks.executions.Fail
+        type: io.kestra.plugin.core.execution.Fail

--- a/src/test/resources/flows/update-fields-jira.yaml
+++ b/src/test/resources/flows/update-fields-jira.yaml
@@ -16,7 +16,7 @@ listeners:
 
 tasks:
   - id: seq
-    type: io.kestra.core.tasks.flows.Sequential
+    type: io.kestra.plugin.core.flow.Sequential
     tasks:
       - id: failed
-        type: io.kestra.core.tasks.executions.Fail
+        type: io.kestra.plugin.core.execution.Fail


### PR DESCRIPTION
Updates the deprecated task identifiers in the test flows to their current names