### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/jira/issues/JiraClient.java
+++ b/src/main/java/io/kestra/plugin/jira/issues/JiraClient.java
@@ -25,7 +25,7 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
-@ToString(exclude = {"username", "password", "accessToken"})
+@ToString
 @EqualsAndHashCode
 @Getter
 @NoArgsConstructor

--- a/src/main/java/io/kestra/plugin/jira/issues/JiraClient.java
+++ b/src/main/java/io/kestra/plugin/jira/issues/JiraClient.java
@@ -25,7 +25,7 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
-@ToString
+@ToString(exclude = {"username", "password", "accessToken"})
 @EqualsAndHashCode
 @Getter
 @NoArgsConstructor
@@ -44,6 +44,7 @@ public abstract class JiraClient extends Task implements RunnableTask<VoidOutput
         description = "Used with `password` for Basic/API token authentication; ignored when an `accessToken` is provided."
     )
     @PluginProperty(secret = true, group = "connection")
+    @ToString.Exclude
     protected Property<String> username;
 
     @Schema(
@@ -51,6 +52,7 @@ public abstract class JiraClient extends Task implements RunnableTask<VoidOutput
         description = "Used with `username` for Basic/API token authentication; ignored when an `accessToken` is provided."
     )
     @PluginProperty(group = "connection", secret = true)
+    @ToString.Exclude
     protected Property<String> password;
 
     @Schema(
@@ -58,6 +60,7 @@ public abstract class JiraClient extends Task implements RunnableTask<VoidOutput
         description = "Bearer token for OAuth; used only when `username`/`password` are not both set."
     )
     @PluginProperty(group = "connection", secret = true)
+    @ToString.Exclude
     protected Property<String> accessToken;
 
     @Schema(
@@ -78,7 +81,7 @@ public abstract class JiraClient extends Task implements RunnableTask<VoidOutput
 
             HttpResponse<String> response = client.request(request, String.class);
 
-            runContext.logger().debug("Response: {}", response.getBody());
+            runContext.logger().debug("Response status: {}", response.getStatus());
 
             return null;
         }
@@ -90,7 +93,7 @@ public abstract class JiraClient extends Task implements RunnableTask<VoidOutput
         String baseUrlRendered = runContext.render(this.baseUrl);
         String payloadRendered = runContext.render(this.payload).as(String.class).orElse(null);
 
-        runContext.logger().debug("Executing request with payload: {}", payloadRendered);
+        runContext.logger().debug("Executing request to '{}'", baseUrlRendered);
 
         var renderedUsername = runContext.render(this.username).as(String.class);
         var renderedPassword = runContext.render(this.password).as(String.class);


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — Lombok `@ToString` on `JiraClient` exposes plaintext secrets in `toString()` output — `src/main/java/io/kestra/plugin/jira/issues/JiraClient.java:28` — Added `@ToString(exclude = {"username", "password", "accessToken"})` on the class and `@ToString.Exclude` on each of the three credential fields (`username`, `password`, `accessToken`) so Lombok-generated `toString()` no longer emits plaintext credentials, including via subclasses that inherit `lombok.tostring.callsuper = call`.
- **LOW** — User-supplied payload and API response body logged at DEBUG level — `src/main/java/io/kestra/plugin/jira/issues/JiraClient.java:93` — Replaced the debug log of the raw rendered payload with a log of the target URL only, and replaced the debug log of the full response body with a log of the response status only, preventing potentially sensitive request/response content from being written to logs.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-jira/issues/87
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
